### PR TITLE
Faction audiences

### DIFF
--- a/src/main/java/co/crystaldev/factions/command/HomeCommand.java
+++ b/src/main/java/co/crystaldev/factions/command/HomeCommand.java
@@ -10,7 +10,6 @@ import co.crystaldev.factions.api.faction.Faction;
 import co.crystaldev.factions.api.faction.permission.Permissions;
 import co.crystaldev.factions.config.MessageConfig;
 import co.crystaldev.factions.config.type.ConfigText;
-import co.crystaldev.factions.util.FactionHelper;
 import co.crystaldev.factions.util.PermissionHelper;
 import co.crystaldev.factions.util.RelationHelper;
 import dev.rollczi.litecommands.annotations.argument.Arg;
@@ -63,7 +62,7 @@ final class HomeCommand extends AlpineCommand {
             if (!event.isCancelled()) {
                 faction.setHome(event.getLocation());
                 if (event.getLocation() == null) {
-                    FactionHelper.broadcast(faction, config.unsetHome.build());
+                    faction.audience().sendMessage(config.unsetHome.build());
                 }
                 return;
             }

--- a/src/main/java/co/crystaldev/factions/command/WarpCommand.java
+++ b/src/main/java/co/crystaldev/factions/command/WarpCommand.java
@@ -86,8 +86,8 @@ final class WarpCommand extends AlpineCommand {
             if (!event.isCancelled()) {
                 // delete warp and notify
                 faction.delWarp(warp);
-                FactionHelper.broadcast(faction, config.unsetWarp.build(
-                            "warp", warp));
+                faction.audience().sendMessage(config.unsetWarp.build(
+                        "warp", warp));
                 return;
             }
         }

--- a/src/main/java/co/crystaldev/factions/util/FactionHelper.java
+++ b/src/main/java/co/crystaldev/factions/util/FactionHelper.java
@@ -20,6 +20,10 @@ import java.util.function.Function;
 @UtilityClass
 public final class FactionHelper {
 
+    /**
+     * @deprecated in favor of {@link Faction#audience()}
+     */
+    @Deprecated
     public static void broadcast(@NotNull Faction faction, @NotNull Component component) {
         for (Member member : faction.getMembers()) {
             Player player = member.getPlayer();


### PR DESCRIPTION
Adds methods to obtain Adventure `Audience` objects for faction members and relations.

Deprecates `FactionHelper#broadcast(Faction, Component)`. The other methods in `FactionHelper` provide contextual formatting based on an observer so they remain. It is definitely possible to replace them with an Adventure implementation but I don't currently have a solid plan of how to go about it.